### PR TITLE
fix(taxisnet): check if firm_act_tab is present before proceeding

### DIFF
--- a/src/TaxisNet.php
+++ b/src/TaxisNet.php
@@ -142,15 +142,19 @@ class TaxisNet
         $vat->stopDate = $this->trim($rec->stop_date);
         $vat->normalVat = $this->trim($rec->normal_vat_system_flag) === 'Y';
 
-        $firms = $this->wrapArray($data->firm_act_tab->item);
+        if (isset($data->firm_act_tab->item)) {
+            $firms = $this->wrapArray($data->firm_act_tab->item);
 
-        foreach ($firms as $firm) {
-            $vat->firms[] = [
-                'code'             => $this->trim($firm->firm_act_code),
-                'description'      => $this->trim($firm->firm_act_descr),
-                'kind'             => $this->trim($firm->firm_act_kind),
-                'kindDescription' => $this->trim($firm->firm_act_kind_descr),
-            ];
+            foreach ($firms as $firm) {
+                $vat->firms[] = [
+                    'code'             => $this->trim($firm->firm_act_code),
+                    'description'      => $this->trim($firm->firm_act_descr),
+                    'kind'             => $this->trim($firm->firm_act_kind),
+                    'kindDescription' => $this->trim($firm->firm_act_kind_descr),
+                ];
+            }
+        } else {
+            $vat->firms = [];
         }
 
         return $vat;


### PR DESCRIPTION
In some cases the ``firm_act_tab`` is missing and the following warning was thrown:

> PHP Warning:  Undefined property: stdClass::$firm_act_tab in /home/pelatologio/app.pelatologio.gr/vendor/firebed/vat-registry/src/TaxisNet.php on line 145

This fix checks first is the  ``firm_act_tab`` and ``item`` before proceeding. 